### PR TITLE
Unset method param to avoid problems with request

### DIFF
--- a/php-mailjet-v3-simple.class.php
+++ b/php-mailjet-v3-simple.class.php
@@ -106,7 +106,13 @@ class Mailjet
         $params  = (sizeof($args) > 0) ? $args[0] : array();
 
         # Request method, GET by default
-        $request = isset($params["method"]) ? strtoupper($params["method"]) : 'GET';
+        if(isset($params["method"])) {
+        	$request = strtoupper($params["method"]);
+        	unset($params['method']);
+        }
+        else {
+        	$request = 'GET';
+        }
 
         # Request ID, empty by default
         $id      = isset($params["ID"]) ? $params["ID"] : '';


### PR DESCRIPTION
Leave the `method` param when the request is made throw an error.
-> Unset it before sending the request resolve the issue.
