### PR TITLE
Update php-mailjet-v3-simple.class.php

### DIFF
--- a/php-mailjet-v3-simple.class.php
+++ b/php-mailjet-v3-simple.class.php
@@ -132,6 +132,7 @@ class Mailjet
         {
             # Request Unique field, empty by default
             $unique  = isset($params["unique"]) ? $params["unique"] : '';
+            unset($params["unique"]);
             # Make request
             $result = $this->sendRequest($resource, $params, $request, $unique);
         }


### PR DESCRIPTION
Need to unset 'unique' parameter, otherwise it will not work and you'll get error like this:
stdClass::__set_state(array(
       'ErrorInfo' => '',
       'ErrorMessage' => 'Invalid json input: object ""->"TContactData" has no property "unique"',
       'StatusCode' => 400,
    ))
