### PR TITLE
Fixing the use of JSON_BIGINT_AS_STRING causing a PHP Warning "json_d…

### DIFF
--- a/src/Mailjet/php-mailjet-v3-simple.class.php
+++ b/src/Mailjet/php-mailjet-v3-simple.class.php
@@ -429,12 +429,12 @@ class Mailjet
             /*
              *  This prevents the rounding error on 32 bits systems with PHP version >= 5.4
              */
-            if (defined('JSON_BIGINT_AS_STRING'))
+            if (version_compare(PHP_VERSION, '5.4.0', '>=') && !(defined('JSON_C_VERSION') && PHP_INT_SIZE > 4))
             {
                 $this->_response = json_decode($buffer, false, 512, JSON_BIGINT_AS_STRING);
             }
             else
-            {   // PHP v <= 5.3.* doens't support the fourth parameter of json_decode
+            {   // PHP v <= 5.3.* and few versions of JSON library (for Ubuntu 14.04 for example) don't support the fourth parameter of json_decode
                 $this->_response = json_decode($buffer, false, 512);
             }
         }


### PR DESCRIPTION
Fixing a bug with the use of JSON_BIGINT_AS_STRING constant, causing a PHP Warning "json_ecode(): option JSON_BIGINT_AS_STRING not implemented" on some versions of JSON library (Ubuntu 14.04 for example)
